### PR TITLE
state "updating" is missing

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -4,6 +4,7 @@
 	"DRIVING":"fährt",
 	"ONLINE":"online",
 	"SLEEPING":"schläft",
+	"UPDATING":"aktualisierung",
 	"UNDEFINED":"offline",
 
 	"SPEED":"Geschwindigkeit",

--- a/translations/en.json
+++ b/translations/en.json
@@ -4,6 +4,7 @@
 	"DRIVING":"driving",
 	"ONLINE":"online",
 	"SLEEPING":"sleeping",
+	"UPDATING":"updating",
 	"UNDEFINED":"offline",
 
 	"SPEED":"Speed",


### PR DESCRIPTION
Last week while updating the firmware of my Tesla I've discovered that the state "updating" wasn't showing on the magicmirror. I hope I didn't miss anything.